### PR TITLE
Update to cmdliner.1.1.0

### DIFF
--- a/ci-server/matrix_ci_server.ml
+++ b/ci-server/matrix_ci_server.ml
@@ -184,7 +184,8 @@ let () =
     Cmd.info "server" ~version:"%%VERSION%%" ~doc in
   exit
   @@ Cmd.eval
-       ( Term.(
+      (Cmd.v info
+        Term.(
            const main
            $ server_name
            $ server_key
@@ -192,5 +193,4 @@ let () =
            $ client_port
            $ federation_port
            $ store_path
-           $ Term.(const setup $ Logs_cli.level ())),
-         info )
+           $ Term.(const setup $ Logs_cli.level ())))

--- a/ci-server/matrix_ci_server.ml
+++ b/ci-server/matrix_ci_server.ml
@@ -181,9 +181,9 @@ let store_path =
 let () =
   let info =
     let doc = "poc of a matrix server" in
-    Term.info "server" ~version:"%%VERSION%%" ~doc in
-  Term.exit
-  @@ Term.eval
+    Cmd.info "server" ~version:"%%VERSION%%" ~doc in
+  exit
+  @@ Cmd.eval
        ( Term.(
            const main
            $ server_name

--- a/ci-server/matrix_ci_server_setup.ml
+++ b/ci-server/matrix_ci_server_setup.ml
@@ -74,4 +74,4 @@ end
 
 let () =
   let info = Cmd.info "server_utility" in
-  exit @@ Cmd.eval (Cmd.group info [User.cmd])
+  exit @@ Cmd.eval' (Cmd.group info [User.cmd])

--- a/ci-server/matrix_ci_server_setup.ml
+++ b/ci-server/matrix_ci_server_setup.ml
@@ -10,12 +10,6 @@ let setup =
   let open Term in
   const setup $ Logs_cli.level ()
 
-let root_cmd =
-  let open Term in
-  let info = info "server_utility" in
-  let term = ret (const (fun () -> `Help (`Pager, None)) $ setup) in
-  term, info
-
 module User = struct
   let f store user_id password () =
     let config = Irmin_git.config store in
@@ -76,13 +70,13 @@ module User = struct
   let cmd =
     let info =
       let doc = "Creates a user." in
-      Term.info "user" ~doc in
+      Cmd.info "user" ~doc in
     let term =
       Term.(app (const Lwt_main.run) (const f $ store $ user_id $ pwd $ setup))
     in
-    term, info
+    Cmd.v info term
 end
 
 let () =
-  let open Term in
-  exit_status @@ eval_choice root_cmd [User.cmd]
+  let info = Cmd.info "server_utility" in
+  exit @@ Cmd.eval (Cmd.group info [User.cmd])

--- a/examples/client/main.ml
+++ b/examples/client/main.ml
@@ -48,11 +48,8 @@ let main {user; password; server} room message =
   Client.post ~job ~room_id client message
 
 let run a b c =
-  match Lwt_main.run (main a b c) with
-  | Ok () -> Ok ()
-  | Error msg ->
-    Printf.printf "Failure was encountered:\n%s\n" msg;
-    Error 1
+  let r = Lwt_main.run (main a b c) in
+  Result.map_error (fun msg -> Printf.sprintf "Failure was encountered:\n%s\n" msg) r
 
 open Cmdliner
 
@@ -79,5 +76,5 @@ let message =
   @@ Arg.(opt (some string)) None
   @@ Arg.info ~doc:"message" ~docv:"MESSAGE" ["message"]
 
-let main = Term.(const run $ remote $ room $ message), Term.info "matrix-client"
-let () = Term.(exit @@ eval main)
+let main = Cmd.v Cmd.(info "matrix-client") Term.(const run $ remote $ room $ message)
+let () = exit @@ Cmd.eval_result main

--- a/matrix-ci-server.Dockerfile
+++ b/matrix-ci-server.Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-11 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev m4 pkg-config git -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 3aeec9a7dbcf8b310f27ff8b337ae612e3b0147b && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 458eb1ee7aae757459b6e91aa22c15b145638f0d && opam update
 COPY --chown=opam \
 	matrix-ci-server.opam \
 	matrix-common.opam \

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -40,6 +40,19 @@ pin-depends: [
   ["dream.~dev"         "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
   ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
   ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
+  # cmdliner.1.1.0
+  ["index.1.6.0"        "git+https://github.com/MisterDA/index.git#1b767f89a41716703a8a067c8470c494332f8fd4"]
+  ["git-unix.3.8.0"     "git+https://github.com/MisterDA/ocaml-git.git#d52aa79f782d3654e3661778811888554d99e337"]
+  ["hxd.0.3.1"          "git+https://github.com/dinosaure/hxd.git#4d3c4b35d74cbd9782d12a8d13a7d047db17e182"]
+  ["irmin.3.0.0"        "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-fs.3.0.0"     "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-git.3.0.0"    "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-graphql.3.0.0" "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-http.3.0.0"   "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-pack.3.0.0"   "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-tezos.3.0.0"  "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["irmin-unix.3.0.0"   "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
+  ["ppx_irmin.3.0.0"    "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -40,19 +40,6 @@ pin-depends: [
   ["dream.~dev"         "git+https://github.com/clecat/dream.git#e60190b8a8ba22c6696b8919b20c0395608ea5b6"]
   ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git#e60190b8a8ba22c6696b8919b20c0395608ea5b6"]
   ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git#e60190b8a8ba22c6696b8919b20c0395608ea5b6"]
-  # cmdliner.1.1.0
-  ["index.1.6.0"        "git+https://github.com/MisterDA/index.git#1b767f89a41716703a8a067c8470c494332f8fd4"]
-  ["git-unix.3.8.0"     "git+https://github.com/MisterDA/ocaml-git.git#d52aa79f782d3654e3661778811888554d99e337"]
-  ["hxd.0.3.1"          "git+https://github.com/dinosaure/hxd.git#4d3c4b35d74cbd9782d12a8d13a7d047db17e182"]
-  ["irmin.3.0.0"        "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-fs.3.0.0"     "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-git.3.0.0"    "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-graphql.3.0.0" "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-http.3.0.0"   "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-pack.3.0.0"   "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-tezos.3.0.0"  "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["irmin-unix.3.0.0"   "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
-  ["ppx_irmin.3.0.0"    "git+https://github.com/MisterDA/irmin.git#ba5265d13514b26bcf2baf45906dafbe3aed8512"]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -37,9 +37,9 @@ depends: [
   "shexp" {with-test}
 ]
 pin-depends: [
-  ["dream.~dev"         "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
-  ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
-  ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
+  ["dream.~dev"         "git+https://github.com/clecat/dream.git#e60190b8a8ba22c6696b8919b20c0395608ea5b6"]
+  ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git#e60190b8a8ba22c6696b8919b20c0395608ea5b6"]
+  ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git#e60190b8a8ba22c6696b8919b20c0395608ea5b6"]
   # cmdliner.1.1.0
   ["index.1.6.0"        "git+https://github.com/MisterDA/index.git#1b767f89a41716703a8a067c8470c494332f8fd4"]
   ["git-unix.3.8.0"     "git+https://github.com/MisterDA/ocaml-git.git#d52aa79f782d3654e3661778811888554d99e337"]

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -37,9 +37,9 @@ depends: [
   "shexp" {with-test}
 ]
 pin-depends: [
-  ["dream.~dev"         "git+https://github.com/clecat/dream.git"]
-  ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git"]
-  ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git"]
+  ["dream.~dev"         "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
+  ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
+  ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git#d04b1a620e6d169fb133f6057a59190c7430bfcc"]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -17,7 +17,7 @@ depends: [
   "astring"
   "base64"
   "bheap"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "ezjsonm"
   "fmt"
   "irmin-fs"

--- a/matrix-common.opam
+++ b/matrix-common.opam
@@ -12,7 +12,7 @@ depends: [
   "ezjsonm"
   "fmt"
   "logs"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "ppxlib"
 ]
 build: [


### PR DESCRIPTION
- update to cmdliner.1.1.0 ;
- ocaml-ci needs opam pin-depends to refer to a specific commit; refer to latest clecat/dream.
- [x] Dream is missing an opam dependency on `multipart_form-lwt` ;
- pin-depends on irmin, index, ocaml-git, hxd latest releases plus cmdliner.1.1.0 patches that I'm maintaining.