### PR TITLE
Update codebase for Irmin 3.0 & remove CI build for 4.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,6 @@ jobs:
           - matrix-ci-server
           - matrix-common
           - matrix-current
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: 4.11.x
-            package: matrix-current
 
     runs-on: ${{ matrix.os }}
 

--- a/ci-server/federation_routes.ml
+++ b/ci-server/federation_routes.ml
@@ -169,13 +169,11 @@ struct
             (* retrieve the room's canonical_alias if any *)
             let%lwt canonical_alias =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.join_rules"] in
+                Store.Tree.find room_tree ["state"; "m.room.join_rules"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -189,13 +187,11 @@ struct
             (* retrieve the room's name if any *)
             let%lwt name =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.name"] in
+                Store.Tree.find room_tree ["state"; "m.room.name"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -206,13 +202,10 @@ struct
             (* retrieve the room's members number *)
             let%lwt num_joined_members =
               let%lwt members =
-                Store.Tree.list room_tree
-                ["state"; "m.room.member"] in
+                Store.Tree.list room_tree ["state"; "m.room.member"] in
               let f n (_, member_tree) =
-                let%lwt event_id =
-                  Store.Tree.get member_tree [] in
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt event_id = Store.Tree.get member_tree [] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -228,13 +221,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt topic =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.topic"] in
+                Store.Tree.find room_tree ["state"; "m.room.topic"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -245,13 +236,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt avatar_url =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.avatar"] in
+                Store.Tree.find room_tree ["state"; "m.room.avatar"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -293,13 +282,11 @@ struct
             (* retrieve the room's canonical_alias if any *)
             let%lwt canonical_alias =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.join_rules"] in
+                Store.Tree.find room_tree ["state"; "m.room.join_rules"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -313,13 +300,11 @@ struct
             (* retrieve the room's name if any *)
             let%lwt name =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.name"] in
+                Store.Tree.find room_tree ["state"; "m.room.name"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -330,13 +315,10 @@ struct
             (* retrieve the room's members number *)
             let%lwt num_joined_members =
               let%lwt members =
-                Store.Tree.list room_tree
-                ["state"; "m.room.member"] in
+                Store.Tree.list room_tree ["state"; "m.room.member"] in
               let f n (_, member_tree) =
-                let%lwt event_id =
-                  Store.Tree.get member_tree [] in
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt event_id = Store.Tree.get member_tree [] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -352,13 +334,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt topic =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.topic"] in
+                Store.Tree.find room_tree ["state"; "m.room.topic"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -369,13 +349,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt avatar_url =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                ["state"; "m.room.avatar"] in
+                Store.Tree.find room_tree ["state"; "m.room.avatar"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -418,12 +396,10 @@ struct
         (* fetch the auth events *)
         let%lwt state_tree =
           Store.get_tree t.store ["rooms"; room_id; "state"] in
-        let%lwt create_event =
-          Store.Tree.get state_tree ["m.room.create"] in
+        let%lwt create_event = Store.Tree.get state_tree ["m.room.create"] in
         let%lwt power_level =
           Store.Tree.get state_tree ["m.room.power_levels"] in
-        let%lwt join_rules =
-          Store.Tree.get state_tree ["m.room.join_rules"] in
+        let%lwt join_rules = Store.Tree.get state_tree ["m.room.join_rules"] in
         let event_content =
           Events.Event_content.Member
             (Events.Event_content.Member.make ~membership:Join ()) in
@@ -500,17 +476,13 @@ struct
                   ["rooms"; room_id; "state"; "m.room.member"; state_key]
                   event_id in
               let%lwt tree =
-                Store.Tree.add tree
-                  ["events"; event_id]
-                  json_event in
+                Store.Tree.add tree ["events"; event_id] json_event in
               (* save the new previous event id*)
               let json =
                 Json_encoding.(construct (list string) [event_id])
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
-                Store.Tree.add tree
-                  ["rooms"; room_id; "head"]
-                  json in
+                Store.Tree.add tree ["rooms"; room_id; "head"] json in
               (* saving update tree *)
               let%lwt return =
                 Store.set_tree
@@ -522,15 +494,12 @@ struct
                 (* fetch the state of the room *)
                 let%lwt tree = Store.tree t.store in
                 let%lwt state_tree =
-                  Store.Tree.get_tree tree
-                    ["rooms"; room_id; "state"] in
+                  Store.Tree.get_tree tree ["rooms"; room_id; "state"] in
                 let%lwt state =
                   Store.Tree.fold
                     ~contents:(fun _ event_id events ->
                       let open Events in
-                      let%lwt json =
-                        Store.Tree.get tree ["events"; event_id]
-                      in
+                      let%lwt json = Store.Tree.get tree ["events"; event_id] in
                       let event =
                         Ezjsonm.from_string json
                         |> Json_encoding.destruct Pdu.encoding in
@@ -662,17 +631,13 @@ struct
                   ["rooms"; room_id; "state"; event_type; state_key]
                   event_id in
               let%lwt tree =
-                Store.Tree.add tree
-                  ["events"; event_id]
-                  json_event in
+                Store.Tree.add tree ["events"; event_id] json_event in
               (* save the new previous event id*)
               let json =
                 Json_encoding.(construct (list string) [event_id])
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
-                Store.Tree.add tree
-                  ["rooms"; room_id; "head"]
-                  json in
+                Store.Tree.add tree ["rooms"; room_id; "head"] json in
               let%lwt () = notify_room_servers t room_id [event] in
               Lwt.return
                 ( tree,
@@ -684,8 +649,7 @@ struct
         Fmt.str "add transaction %s from %s" txn_id
           (Request.get_origin transaction) in
       let%lwt return =
-        Store.set_tree ~info:(Helper.info t ~message) t.store []
-          tree in
+        Store.set_tree ~info:(Helper.info t ~message) t.store [] tree in
       match return with
       | Ok () ->
         let response =
@@ -723,8 +687,7 @@ struct
           if List.exists (String.equal event_id) event_ids then
             Lwt.return (event_ids, events)
           else
-            let%lwt json =
-              Store.Tree.find tree ["events"; event_id] in
+            let%lwt json = Store.Tree.find tree ["events"; event_id] in
             match json with
             | None -> Lwt.return (event_ids, events)
             | Some json ->
@@ -779,8 +742,7 @@ struct
           if List.exists (String.equal event_id) event_ids then
             Lwt.return (event_ids, events)
           else
-            let%lwt json =
-              Store.Tree.find tree ["events"; event_id] in
+            let%lwt json = Store.Tree.find tree ["events"; event_id] in
             match json with
             | None -> Lwt.return (event_ids, events)
             | Some json ->
@@ -818,8 +780,7 @@ struct
         (* fetch the event *)
         let event_id = Identifiers.Event_id.of_string_exn event_id in
         let%lwt tree = Store.tree t.store in
-        let%lwt json =
-          Store.Tree.find tree ["events"; event_id] in
+        let%lwt json = Store.Tree.find tree ["events"; event_id] in
         match json with
         | None -> Dream.json ~status:`Forbidden {|{"errcode": "M_FORBIDDEN"}|}
         | Some json ->
@@ -833,8 +794,7 @@ struct
             let auth_events = Events.Pdu.get_auth_events event in
             let f l event_id =
               let event_id = Identifiers.Event_id.of_string_exn event_id in
-              let%lwt json =
-                Store.Tree.find tree ["events"; event_id] in
+              let%lwt json = Store.Tree.find tree ["events"; event_id] in
               match json with
               | None -> Lwt.return l
               | Some json ->
@@ -908,8 +868,7 @@ struct
       | Some room_alias -> (
         let room_alias, _ = Identifiers.Room_alias.of_string_exn room_alias in
         let%lwt tree = Store.tree t.store in
-        let%lwt room_id =
-          Store.Tree.find tree ["aliases"; room_alias] in
+        let%lwt room_id = Store.Tree.find tree ["aliases"; room_alias] in
         match room_id with
         | None ->
           Dream.json ~status:`Not_Found
@@ -931,8 +890,7 @@ struct
           {|{"errcode": "M_NOT_FOUND", "User does not exist."}|}
       | Some user_id -> (
         let%lwt tree = Store.tree t.store in
-        let%lwt user_tree =
-          Store.Tree.find_tree tree ["users"; user_id] in
+        let%lwt user_tree = Store.Tree.find_tree tree ["users"; user_id] in
         match user_tree with
         | None ->
           Dream.json ~status:`Not_Found
@@ -943,8 +901,7 @@ struct
             match field with
             | Some "avatar_url" -> Lwt.return (None, None)
             | _ ->
-              let%lwt displayname =
-                Store.Tree.get user_tree ["username"] in
+              let%lwt displayname = Store.Tree.get user_tree ["username"] in
               Lwt.return (None, Some displayname) in
           let response =
             Response.make ?avatar_url ?displayname ()
@@ -965,8 +922,7 @@ struct
       let open User.Devices in
       let user_id = Dream.param "user_id" request in
       let%lwt tree = Store.tree t.store in
-      let%lwt user_tree =
-        Store.Tree.find_tree tree ["users"; user_id] in
+      let%lwt user_tree = Store.Tree.find_tree tree ["users"; user_id] in
       match user_tree with
       | None ->
         Dream.json ~status:`Not_Found

--- a/ci-server/federation_routes.ml
+++ b/ci-server/federation_routes.ml
@@ -161,7 +161,7 @@ struct
       let open Public_rooms.Get_public_rooms in
       let%lwt tree = Store.tree t.store in
       (* retrieve the list of the rooms *)
-      let%lwt rooms = Store.Tree.list tree @@ Store.Key.v ["rooms"] in
+      let%lwt rooms = Store.Tree.list tree ["rooms"] in
       (* filter out the public rooms*)
       let%lwt public_rooms =
         Lwt_list.map_p
@@ -170,12 +170,12 @@ struct
             let%lwt canonical_alias =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.join_rules"] in
+                ["state"; "m.room.join_rules"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -190,12 +190,12 @@ struct
             let%lwt name =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.name"] in
+                ["state"; "m.room.name"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -207,12 +207,12 @@ struct
             let%lwt num_joined_members =
               let%lwt members =
                 Store.Tree.list room_tree
-                @@ Store.Key.v ["state"; "m.room.member"] in
+                ["state"; "m.room.member"] in
               let f n (_, member_tree) =
                 let%lwt event_id =
-                  Store.Tree.get member_tree @@ Store.Key.v [] in
+                  Store.Tree.get member_tree [] in
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -229,12 +229,12 @@ struct
             let%lwt topic =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.topic"] in
+                ["state"; "m.room.topic"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -246,12 +246,12 @@ struct
             let%lwt avatar_url =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.avatar"] in
+                ["state"; "m.room.avatar"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -285,7 +285,7 @@ struct
       let open Public_rooms.Filter_public_rooms in
       let%lwt tree = Store.tree t.store in
       (* retrieve the list of the rooms *)
-      let%lwt rooms = Store.Tree.list tree @@ Store.Key.v ["rooms"] in
+      let%lwt rooms = Store.Tree.list tree ["rooms"] in
       (* filter out the public rooms*)
       let%lwt public_rooms =
         Lwt_list.map_p
@@ -294,12 +294,12 @@ struct
             let%lwt canonical_alias =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.join_rules"] in
+                ["state"; "m.room.join_rules"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -314,12 +314,12 @@ struct
             let%lwt name =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.name"] in
+                ["state"; "m.room.name"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -331,12 +331,12 @@ struct
             let%lwt num_joined_members =
               let%lwt members =
                 Store.Tree.list room_tree
-                @@ Store.Key.v ["state"; "m.room.member"] in
+                ["state"; "m.room.member"] in
               let f n (_, member_tree) =
                 let%lwt event_id =
-                  Store.Tree.get member_tree @@ Store.Key.v [] in
+                  Store.Tree.get member_tree [] in
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -353,12 +353,12 @@ struct
             let%lwt topic =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.topic"] in
+                ["state"; "m.room.topic"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -370,12 +370,12 @@ struct
             let%lwt avatar_url =
               let%lwt event_id =
                 Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.avatar"] in
+                ["state"; "m.room.avatar"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
                 let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                  Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -417,13 +417,13 @@ struct
       if List.exists (String.equal room_version) versions then
         (* fetch the auth events *)
         let%lwt state_tree =
-          Store.get_tree t.store (Store.Key.v ["rooms"; room_id; "state"]) in
+          Store.get_tree t.store ["rooms"; room_id; "state"] in
         let%lwt create_event =
-          Store.Tree.get state_tree (Store.Key.v ["m.room.create"]) in
+          Store.Tree.get state_tree ["m.room.create"] in
         let%lwt power_level =
-          Store.Tree.get state_tree (Store.Key.v ["m.room.power_levels"]) in
+          Store.Tree.get state_tree ["m.room.power_levels"] in
         let%lwt join_rules =
-          Store.Tree.get state_tree (Store.Key.v ["m.room.join_rules"]) in
+          Store.Tree.get state_tree ["m.room.join_rules"] in
         let event_content =
           Events.Event_content.Member
             (Events.Event_content.Member.make ~membership:Join ()) in
@@ -497,12 +497,11 @@ struct
               let%lwt tree = Store.tree t.store in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v
-                     ["rooms"; room_id; "state"; "m.room.member"; state_key])
+                  ["rooms"; room_id; "state"; "m.room.member"; state_key]
                   event_id in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v ["events"; event_id])
+                  ["events"; event_id]
                   json_event in
               (* save the new previous event id*)
               let json =
@@ -510,13 +509,13 @@ struct
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v ["rooms"; room_id; "head"])
+                  ["rooms"; room_id; "head"]
                   json in
               (* saving update tree *)
               let%lwt return =
                 Store.set_tree
                   ~info:(Helper.info t ~message:"add joining member")
-                  t.store (Store.Key.v []) tree in
+                  t.store [] tree in
               match return with
               | Ok () ->
                 let%lwt () = notify_room_servers t room_id [member_event] in
@@ -524,13 +523,13 @@ struct
                 let%lwt tree = Store.tree t.store in
                 let%lwt state_tree =
                   Store.Tree.get_tree tree
-                    (Store.Key.v ["rooms"; room_id; "state"]) in
+                    ["rooms"; room_id; "state"] in
                 let%lwt state =
                   Store.Tree.fold
                     ~contents:(fun _ event_id events ->
                       let open Events in
                       let%lwt json =
-                        Store.Tree.get tree @@ Store.Key.v ["events"; event_id]
+                        Store.Tree.get tree ["events"; event_id]
                       in
                       let event =
                         Ezjsonm.from_string json
@@ -561,7 +560,7 @@ struct
       let event_id = Dream.param "event_id" request in
       let%lwt tree = Store.tree t.store in
       let event_id = Identifiers.Event_id.of_string_exn event_id in
-      let%lwt json = Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+      let%lwt json = Store.Tree.find tree ["events"; event_id] in
       match json with
       | None -> Dream.json ~status:`Forbidden {|{"errcode": "M_UNKNOWN"}|}
       | Some json ->
@@ -660,12 +659,11 @@ struct
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v
-                     ["rooms"; room_id; "state"; event_type; state_key])
+                  ["rooms"; room_id; "state"; event_type; state_key]
                   event_id in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v ["events"; event_id])
+                  ["events"; event_id]
                   json_event in
               (* save the new previous event id*)
               let json =
@@ -673,7 +671,7 @@ struct
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v ["rooms"; room_id; "head"])
+                  ["rooms"; room_id; "head"]
                   json in
               let%lwt () = notify_room_servers t room_id [event] in
               Lwt.return
@@ -686,7 +684,7 @@ struct
         Fmt.str "add transaction %s from %s" txn_id
           (Request.get_origin transaction) in
       let%lwt return =
-        Store.set_tree ~info:(Helper.info t ~message) t.store (Store.Key.v [])
+        Store.set_tree ~info:(Helper.info t ~message) t.store []
           tree in
       match return with
       | Ok () ->
@@ -726,7 +724,7 @@ struct
             Lwt.return (event_ids, events)
           else
             let%lwt json =
-              Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+              Store.Tree.find tree ["events"; event_id] in
             match json with
             | None -> Lwt.return (event_ids, events)
             | Some json ->
@@ -782,7 +780,7 @@ struct
             Lwt.return (event_ids, events)
           else
             let%lwt json =
-              Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+              Store.Tree.find tree ["events"; event_id] in
             match json with
             | None -> Lwt.return (event_ids, events)
             | Some json ->
@@ -821,7 +819,7 @@ struct
         let event_id = Identifiers.Event_id.of_string_exn event_id in
         let%lwt tree = Store.tree t.store in
         let%lwt json =
-          Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+          Store.Tree.find tree ["events"; event_id] in
         match json with
         | None -> Dream.json ~status:`Forbidden {|{"errcode": "M_FORBIDDEN"}|}
         | Some json ->
@@ -836,7 +834,7 @@ struct
             let f l event_id =
               let event_id = Identifiers.Event_id.of_string_exn event_id in
               let%lwt json =
-                Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+                Store.Tree.find tree ["events"; event_id] in
               match json with
               | None -> Lwt.return l
               | Some json ->
@@ -911,7 +909,7 @@ struct
         let room_alias, _ = Identifiers.Room_alias.of_string_exn room_alias in
         let%lwt tree = Store.tree t.store in
         let%lwt room_id =
-          Store.Tree.find tree @@ Store.Key.v ["aliases"; room_alias] in
+          Store.Tree.find tree ["aliases"; room_alias] in
         match room_id with
         | None ->
           Dream.json ~status:`Not_Found
@@ -934,7 +932,7 @@ struct
       | Some user_id -> (
         let%lwt tree = Store.tree t.store in
         let%lwt user_tree =
-          Store.Tree.find_tree tree @@ Store.Key.v ["users"; user_id] in
+          Store.Tree.find_tree tree ["users"; user_id] in
         match user_tree with
         | None ->
           Dream.json ~status:`Not_Found
@@ -946,7 +944,7 @@ struct
             | Some "avatar_url" -> Lwt.return (None, None)
             | _ ->
               let%lwt displayname =
-                Store.Tree.get user_tree @@ Store.Key.v ["username"] in
+                Store.Tree.get user_tree ["username"] in
               Lwt.return (None, Some displayname) in
           let response =
             Response.make ?avatar_url ?displayname ()
@@ -968,7 +966,7 @@ struct
       let user_id = Dream.param "user_id" request in
       let%lwt tree = Store.tree t.store in
       let%lwt user_tree =
-        Store.Tree.find_tree tree @@ Store.Key.v ["users"; user_id] in
+        Store.Tree.find_tree tree ["users"; user_id] in
       match user_tree with
       | None ->
         Dream.json ~status:`Not_Found

--- a/ci-server/helper.ml
+++ b/ci-server/helper.ml
@@ -11,14 +11,12 @@ struct
   let is_room_user (t : Common_routes.t) room_id user_id =
     let%lwt tree = Store.tree t.store in
     let%lwt event_id =
-      Store.Tree.find tree
-        ["rooms"; room_id; "state"; "m.room.member"; user_id]
+      Store.Tree.find tree ["rooms"; room_id; "state"; "m.room.member"; user_id]
     in
     match event_id with
     | None -> Lwt.return false
     | Some event_id -> (
-      let%lwt state_event =
-        Store.Tree.get tree ["events"; event_id] in
+      let%lwt state_event = Store.Tree.get tree ["events"; event_id] in
       let state_event =
         Json_encoding.destruct Events.State_event.encoding
           (Ezjsonm.value_from_string state_event) in
@@ -33,9 +31,8 @@ struct
   let time () = Unix.time () |> Float.to_int |> ( * ) 1000
 
   let info (t : Common_routes.t) ?(message = "") () =
-    Store.Info.v
-      ~author:t.server_name ~message:message
-      @@ Int64.of_float (Unix.gettimeofday ())
+    Store.Info.v ~author:t.server_name ~message
+    @@ Int64.of_float (Unix.gettimeofday ())
 
   let compute_hash_and_sign (t : Common_routes.t) pdu =
     let open Events in
@@ -92,8 +89,7 @@ struct
     sha256
 
   let is_valid_key key_tree =
-    let%lwt valid_until =
-      Store.Tree.get key_tree ["valid_until"] in
+    let%lwt valid_until = Store.Tree.get key_tree ["valid_until"] in
     let expires_at = Float.of_string valid_until in
     let current_time = Unix.gettimeofday () in
     Lwt.return (expires_at > current_time)
@@ -179,18 +175,14 @@ struct
       let f (key_id, signature) =
         (* check if we have the key, if not, try to fetch it *)
         let%lwt tree = Store.tree t.store in
-        let%lwt key_tree =
-          Store.Tree.find_tree tree ["keys"; origin; key_id]
-        in
+        let%lwt key_tree = Store.Tree.find_tree tree ["keys"; origin; key_id] in
         let%lwt key_tree =
           if key_tree = None then
             let%lwt key_s = fetching_key t origin key_id in
             match key_s with
             | Some (key_s, valid_until) -> (
               let%lwt tree =
-                Store.Tree.add tree
-                  ["keys"; origin; key_id; "key"]
-                  key_s in
+                Store.Tree.add tree ["keys"; origin; key_id; "key"] key_s in
               let%lwt tree =
                 Store.Tree.add tree
                   ["keys"; origin; key_id; "valid_until"]
@@ -200,9 +192,7 @@ struct
                   ~info:(info t ~message:"add server key")
                   t.store [] tree in
               match return with
-              | Ok () ->
-                Store.Tree.find_tree tree
-                ["keys"; origin; key_id]
+              | Ok () -> Store.Tree.find_tree tree ["keys"; origin; key_id]
               | Error write_error ->
                 Dream.error (fun m ->
                     m "Write error: %a"
@@ -225,8 +215,7 @@ struct
   (* Use older/replaced events once they are implemented *)
   let get_room_prev_events (t : Common_routes.t) room_id =
     let%lwt tree = Store.tree t.store in
-    let%lwt json =
-      Store.Tree.get tree ["rooms"; room_id; "head"] in
+    let%lwt json = Store.Tree.get tree ["rooms"; room_id; "head"] in
     let events_id =
       Ezjsonm.from_string json |> Json_encoding.(destruct (list string)) in
     let open Events in
@@ -241,8 +230,7 @@ struct
   let fetch_joined_servers (t : Common_routes.t) room_id =
     let%lwt tree = Store.tree t.store in
     let%lwt members =
-      Store.Tree.list tree
-      ["rooms"; room_id; "state"; "m.room.member"] in
+      Store.Tree.list tree ["rooms"; room_id; "state"; "m.room.member"] in
     let f l (_, member_tree) =
       let%lwt event_id = Store.Tree.get member_tree [] in
       let%lwt json = Store.Tree.get tree ["events"; event_id] in

--- a/ci-server/matrix_ci_server.ml
+++ b/ci-server/matrix_ci_server.ml
@@ -122,7 +122,7 @@ let main
      let ctx = fill_http ctx federation_port stack in
      let config = Irmin_git.config store_path in
      let%lwt repo = Store.Store.Repo.v config in
-     let%lwt store = Store.Store.master repo in
+     let%lwt store = Store.Store.main repo in
      let info =
        Common_routes.{server_name; key_name; priv_key; pub_key; ctx; store}
      in

--- a/ci-server/matrix_ci_server_setup.ml
+++ b/ci-server/matrix_ci_server_setup.ml
@@ -34,18 +34,13 @@ module User = struct
       let hashed = Digestif.BLAKE2B.to_hex digest in
       let%lwt tree = Store.tree store in
       let%lwt tree =
-        Store.Tree.add tree ["users"; user_id; "username"] user_id
-      in
-      let%lwt tree =
-        Store.Tree.add tree ["users"; user_id; "salt"] salt in
-      let%lwt tree =
-        Store.Tree.add tree ["users"; user_id; "password"] hashed
-      in
+        Store.Tree.add tree ["users"; user_id; "username"] user_id in
+      let%lwt tree = Store.Tree.add tree ["users"; user_id; "salt"] salt in
+      let%lwt tree = Store.Tree.add tree ["users"; user_id; "password"] hashed in
       let%lwt return =
         Store.set_tree
           ~info:(fun () ->
-            Store.Info.v
-            ~author:"matrix-ci-server-setup" ~message:"add user"
+            Store.Info.v ~author:"matrix-ci-server-setup" ~message:"add user"
             @@ Int64.of_float (Unix.gettimeofday ()))
           store [] tree in
       match return with

--- a/ci-server/middleware.ml
+++ b/ci-server/middleware.ml
@@ -41,8 +41,7 @@ struct
       {|{"errcode": "M_UNKNOWN_TOKEN", "error": "No access token matched"}|}
 
   let is_valid_token token_tree =
-    let%lwt expires_at =
-      Store.Tree.get token_tree ["expires_at"] in
+    let%lwt expires_at = Store.Tree.get token_tree ["expires_at"] in
     let expires_at = Float.of_string expires_at in
     let current_time = Unix.gettimeofday () in
     Lwt.return (expires_at > current_time)
@@ -62,8 +61,7 @@ struct
     | Some token -> (
       let%lwt tree = Store.tree t.store in
       (* fetch the token *)
-      let%lwt token_tree =
-        Store.Tree.find_tree tree ["tokens"; token] in
+      let%lwt token_tree = Store.Tree.find_tree tree ["tokens"; token] in
       match token_tree with
       | None -> unkown_token
       | Some token_tree -> (
@@ -72,29 +70,24 @@ struct
         else
           (* fetch the device *)
           let%lwt device = Store.Tree.get token_tree ["device"] in
-          let%lwt device_tree =
-            Store.Tree.find_tree tree ["devices"; device] in
+          let%lwt device_tree = Store.Tree.find_tree tree ["devices"; device] in
           match device_tree with
           | None -> unkown_token
           | Some device_tree -> (
             (* fetch the user *)
-            let%lwt user_id =
-              Store.Tree.get device_tree ["user_id"] in
-            let%lwt user_tree =
-              Store.Tree.find_tree tree ["users"; user_id] in
+            let%lwt user_id = Store.Tree.get device_tree ["user_id"] in
+            let%lwt user_tree = Store.Tree.find_tree tree ["users"; user_id] in
             match user_tree with
             | None -> unkown_token
             | Some user_tree -> (
               (* verify the device is still listed in the user's devices *)
               let%lwt user_device =
-                Store.Tree.find_tree user_tree ["devices"; device]
-              in
+                Store.Tree.find_tree user_tree ["devices"; device] in
               match user_device with
               | None -> unkown_token
               | Some _ ->
                 (* verify the token is still the actual device token *)
-                let%lwt device_token =
-                  Store.Tree.get device_tree ["token"] in
+                let%lwt device_token = Store.Tree.get device_tree ["token"] in
                 if device_token <> token then unkown_token
                 else
                   handler
@@ -179,17 +172,14 @@ struct
     | Some (origin, key_id, signature) -> (
       let%lwt tree = Store.tree t.store in
       (* fetch the server's key *)
-      let%lwt key_tree =
-        Store.Tree.find_tree tree ["keys"; origin; key_id] in
+      let%lwt key_tree = Store.Tree.find_tree tree ["keys"; origin; key_id] in
       let%lwt key_tree =
         if key_tree = None then
           let%lwt key_s = Helper.fetching_key t origin key_id in
           match key_s with
           | Some (key_s, valid_until) -> (
             let%lwt tree =
-              Store.Tree.add tree
-                ["keys"; origin; key_id; "key"]
-                key_s in
+              Store.Tree.add tree ["keys"; origin; key_id; "key"] key_s in
             let%lwt tree =
               Store.Tree.add tree
                 ["keys"; origin; key_id; "valid_until"]
@@ -199,8 +189,7 @@ struct
                 ~info:(Helper.info t ~message:"add server key")
                 t.store [] tree in
             match return with
-            | Ok () ->
-              Store.Tree.find_tree tree ["keys"; origin; key_id]
+            | Ok () -> Store.Tree.find_tree tree ["keys"; origin; key_id]
             | Error write_error ->
               Dream.error (fun m ->
                   m "Write error: %a"

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -20,8 +20,8 @@ depends: [
   "cmdliner"
   "ezjsonm"
   "fmt"
-  "irmin-fs"
-  "irmin-unix"
+  "irmin-fs" {>= "3.0"}
+  "irmin-unix" {>= "3.0"}
   "logs"
   "tcpip" {>= "7.0.0"}
   "mirage-crypto-ec"


### PR DESCRIPTION
The main goal of this pull request is to move to the recently released irmin 3.0.
We should wait for `Irmin.3.0` to be fully released before merging this pull request but at least it is ready.
This PR should also pave the way for [the update to Cmdliner 1.1](https://github.com/mirage/ocaml-matrix/pull/18)

The three main changes that impacts the code are the following:
- Renaming of `Store.Key` to `Store.Path`
- Moving of `Irmin.Info` to `Store.Info`
- Deprecation of master for main
All those changes have been taken into account, however for `Store.Key` it appeared that using it was not needed at all, so I simply removed it.

Lastly, I have removed a remnant of build for ocaml 4.11 in the CI.