### PR TITLE
Update CI and Dockerfile with new main branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master, mirage ]
+    branches: [ main, mirage ]
   pull_request:
-    branches: [ master, mirage ]
+    branches: [ main, mirage ]
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,6 @@ jobs:
           - matrix-ci-server
           - matrix-common
           - matrix-current
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: 4.11.x
-            package: matrix-current
 
     runs-on: ${{ matrix.os }}
 

--- a/matrix-ci-server.Dockerfile
+++ b/matrix-ci-server.Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-11 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev m4 pkg-config git -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 3aeec9a7dbcf8b310f27ff8b337ae612e3b0147b && opam update
+RUN cd ~/opam-repository && git pull origin main && git reset --hard 3aeec9a7dbcf8b310f27ff8b337ae612e3b0147b && opam update
 COPY --chown=opam \
 	matrix-ci-server.opam \
 	matrix-common.opam \


### PR DESCRIPTION
Renaming the primary branch from `master` to `main` has broken the CI and the Dockerfile, this PR updates the needed files accordingly.

It also takes the opportunity to remove the remnant in the CI which would build `matrix-current` for ocaml 4.11.x