### PR TITLE
Update to Irmin 3.0

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -14,7 +14,7 @@ let setup_server () =
   |> map ~f:ignore
   >> mkdir "/tmp/ocaml-matrix/"
   >> chdir "/tmp/ocaml-matrix"
-       (run "git" ["init"; "--initial-branch=master"]
+       (run "git" ["init"; "--initial-branch=main"]
        >> run "touch" ["init"]
        >> run "git" ["add"; "init"]
        >> run "git" ["commit"; "-m"; "init"]

--- a/ci-server/federation_routes.ml
+++ b/ci-server/federation_routes.ml
@@ -161,7 +161,7 @@ struct
       let open Public_rooms.Get_public_rooms in
       let%lwt tree = Store.tree t.store in
       (* retrieve the list of the rooms *)
-      let%lwt rooms = Store.Tree.list tree @@ Store.Key.v ["rooms"] in
+      let%lwt rooms = Store.Tree.list tree ["rooms"] in
       (* filter out the public rooms*)
       let%lwt public_rooms =
         Lwt_list.map_p
@@ -169,13 +169,11 @@ struct
             (* retrieve the room's canonical_alias if any *)
             let%lwt canonical_alias =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.join_rules"] in
+                Store.Tree.find room_tree ["state"; "m.room.join_rules"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -189,13 +187,11 @@ struct
             (* retrieve the room's name if any *)
             let%lwt name =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.name"] in
+                Store.Tree.find room_tree ["state"; "m.room.name"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -206,13 +202,10 @@ struct
             (* retrieve the room's members number *)
             let%lwt num_joined_members =
               let%lwt members =
-                Store.Tree.list room_tree
-                @@ Store.Key.v ["state"; "m.room.member"] in
+                Store.Tree.list room_tree ["state"; "m.room.member"] in
               let f n (_, member_tree) =
-                let%lwt event_id =
-                  Store.Tree.get member_tree @@ Store.Key.v [] in
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt event_id = Store.Tree.get member_tree [] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -228,13 +221,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt topic =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.topic"] in
+                Store.Tree.find room_tree ["state"; "m.room.topic"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -245,13 +236,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt avatar_url =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.avatar"] in
+                Store.Tree.find room_tree ["state"; "m.room.avatar"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -285,7 +274,7 @@ struct
       let open Public_rooms.Filter_public_rooms in
       let%lwt tree = Store.tree t.store in
       (* retrieve the list of the rooms *)
-      let%lwt rooms = Store.Tree.list tree @@ Store.Key.v ["rooms"] in
+      let%lwt rooms = Store.Tree.list tree ["rooms"] in
       (* filter out the public rooms*)
       let%lwt public_rooms =
         Lwt_list.map_p
@@ -293,13 +282,11 @@ struct
             (* retrieve the room's canonical_alias if any *)
             let%lwt canonical_alias =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.join_rules"] in
+                Store.Tree.find room_tree ["state"; "m.room.join_rules"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -313,13 +300,11 @@ struct
             (* retrieve the room's name if any *)
             let%lwt name =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.name"] in
+                Store.Tree.find room_tree ["state"; "m.room.name"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -330,13 +315,10 @@ struct
             (* retrieve the room's members number *)
             let%lwt num_joined_members =
               let%lwt members =
-                Store.Tree.list room_tree
-                @@ Store.Key.v ["state"; "m.room.member"] in
+                Store.Tree.list room_tree ["state"; "m.room.member"] in
               let f n (_, member_tree) =
-                let%lwt event_id =
-                  Store.Tree.get member_tree @@ Store.Key.v [] in
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt event_id = Store.Tree.get member_tree [] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -352,13 +334,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt topic =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.topic"] in
+                Store.Tree.find room_tree ["state"; "m.room.topic"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -369,13 +349,11 @@ struct
             (* retrieve the room's topic if any *)
             let%lwt avatar_url =
               let%lwt event_id =
-                Store.Tree.find room_tree
-                @@ Store.Key.v ["state"; "m.room.avatar"] in
+                Store.Tree.find room_tree ["state"; "m.room.avatar"] in
               match event_id with
               | None -> Lwt.return_none
               | Some event_id -> (
-                let%lwt json =
-                  Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+                let%lwt json = Store.Tree.get tree ["events"; event_id] in
                 let event =
                   Json_encoding.destruct Events.State_event.encoding
                     (Ezjsonm.value_from_string json) in
@@ -417,13 +395,11 @@ struct
       if List.exists (String.equal room_version) versions then
         (* fetch the auth events *)
         let%lwt state_tree =
-          Store.get_tree t.store (Store.Key.v ["rooms"; room_id; "state"]) in
-        let%lwt create_event =
-          Store.Tree.get state_tree (Store.Key.v ["m.room.create"]) in
+          Store.get_tree t.store ["rooms"; room_id; "state"] in
+        let%lwt create_event = Store.Tree.get state_tree ["m.room.create"] in
         let%lwt power_level =
-          Store.Tree.get state_tree (Store.Key.v ["m.room.power_levels"]) in
-        let%lwt join_rules =
-          Store.Tree.get state_tree (Store.Key.v ["m.room.join_rules"]) in
+          Store.Tree.get state_tree ["m.room.power_levels"] in
+        let%lwt join_rules = Store.Tree.get state_tree ["m.room.join_rules"] in
         let event_content =
           Events.Event_content.Member
             (Events.Event_content.Member.make ~membership:Join ()) in
@@ -497,41 +473,33 @@ struct
               let%lwt tree = Store.tree t.store in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v
-                     ["rooms"; room_id; "state"; "m.room.member"; state_key])
+                  ["rooms"; room_id; "state"; "m.room.member"; state_key]
                   event_id in
               let%lwt tree =
-                Store.Tree.add tree
-                  (Store.Key.v ["events"; event_id])
-                  json_event in
+                Store.Tree.add tree ["events"; event_id] json_event in
               (* save the new previous event id*)
               let json =
                 Json_encoding.(construct (list string) [event_id])
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
-                Store.Tree.add tree
-                  (Store.Key.v ["rooms"; room_id; "head"])
-                  json in
+                Store.Tree.add tree ["rooms"; room_id; "head"] json in
               (* saving update tree *)
               let%lwt return =
                 Store.set_tree
                   ~info:(Helper.info t ~message:"add joining member")
-                  t.store (Store.Key.v []) tree in
+                  t.store [] tree in
               match return with
               | Ok () ->
                 let%lwt () = notify_room_servers t room_id [member_event] in
                 (* fetch the state of the room *)
                 let%lwt tree = Store.tree t.store in
                 let%lwt state_tree =
-                  Store.Tree.get_tree tree
-                    (Store.Key.v ["rooms"; room_id; "state"]) in
+                  Store.Tree.get_tree tree ["rooms"; room_id; "state"] in
                 let%lwt state =
                   Store.Tree.fold
                     ~contents:(fun _ event_id events ->
                       let open Events in
-                      let%lwt json =
-                        Store.Tree.get tree @@ Store.Key.v ["events"; event_id]
-                      in
+                      let%lwt json = Store.Tree.get tree ["events"; event_id] in
                       let event =
                         Ezjsonm.from_string json
                         |> Json_encoding.destruct Pdu.encoding in
@@ -561,7 +529,7 @@ struct
       let event_id = Dream.param "event_id" request in
       let%lwt tree = Store.tree t.store in
       let event_id = Identifiers.Event_id.of_string_exn event_id in
-      let%lwt json = Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+      let%lwt json = Store.Tree.find tree ["events"; event_id] in
       match json with
       | None -> Dream.json ~status:`Forbidden {|{"errcode": "M_UNKNOWN"}|}
       | Some json ->
@@ -660,21 +628,16 @@ struct
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v
-                     ["rooms"; room_id; "state"; event_type; state_key])
+                  ["rooms"; room_id; "state"; event_type; state_key]
                   event_id in
               let%lwt tree =
-                Store.Tree.add tree
-                  (Store.Key.v ["events"; event_id])
-                  json_event in
+                Store.Tree.add tree ["events"; event_id] json_event in
               (* save the new previous event id*)
               let json =
                 Json_encoding.(construct (list string) [event_id])
                 |> Ezjsonm.value_to_string in
               let%lwt tree =
-                Store.Tree.add tree
-                  (Store.Key.v ["rooms"; room_id; "head"])
-                  json in
+                Store.Tree.add tree ["rooms"; room_id; "head"] json in
               let%lwt () = notify_room_servers t room_id [event] in
               Lwt.return
                 ( tree,
@@ -686,8 +649,7 @@ struct
         Fmt.str "add transaction %s from %s" txn_id
           (Request.get_origin transaction) in
       let%lwt return =
-        Store.set_tree ~info:(Helper.info t ~message) t.store (Store.Key.v [])
-          tree in
+        Store.set_tree ~info:(Helper.info t ~message) t.store [] tree in
       match return with
       | Ok () ->
         let response =
@@ -725,8 +687,7 @@ struct
           if List.exists (String.equal event_id) event_ids then
             Lwt.return (event_ids, events)
           else
-            let%lwt json =
-              Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+            let%lwt json = Store.Tree.find tree ["events"; event_id] in
             match json with
             | None -> Lwt.return (event_ids, events)
             | Some json ->
@@ -781,8 +742,7 @@ struct
           if List.exists (String.equal event_id) event_ids then
             Lwt.return (event_ids, events)
           else
-            let%lwt json =
-              Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+            let%lwt json = Store.Tree.find tree ["events"; event_id] in
             match json with
             | None -> Lwt.return (event_ids, events)
             | Some json ->
@@ -820,8 +780,7 @@ struct
         (* fetch the event *)
         let event_id = Identifiers.Event_id.of_string_exn event_id in
         let%lwt tree = Store.tree t.store in
-        let%lwt json =
-          Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+        let%lwt json = Store.Tree.find tree ["events"; event_id] in
         match json with
         | None -> Dream.json ~status:`Forbidden {|{"errcode": "M_FORBIDDEN"}|}
         | Some json ->
@@ -835,8 +794,7 @@ struct
             let auth_events = Events.Pdu.get_auth_events event in
             let f l event_id =
               let event_id = Identifiers.Event_id.of_string_exn event_id in
-              let%lwt json =
-                Store.Tree.find tree @@ Store.Key.v ["events"; event_id] in
+              let%lwt json = Store.Tree.find tree ["events"; event_id] in
               match json with
               | None -> Lwt.return l
               | Some json ->
@@ -910,8 +868,7 @@ struct
       | Some room_alias -> (
         let room_alias, _ = Identifiers.Room_alias.of_string_exn room_alias in
         let%lwt tree = Store.tree t.store in
-        let%lwt room_id =
-          Store.Tree.find tree @@ Store.Key.v ["aliases"; room_alias] in
+        let%lwt room_id = Store.Tree.find tree ["aliases"; room_alias] in
         match room_id with
         | None ->
           Dream.json ~status:`Not_Found
@@ -933,8 +890,7 @@ struct
           {|{"errcode": "M_NOT_FOUND", "User does not exist."}|}
       | Some user_id -> (
         let%lwt tree = Store.tree t.store in
-        let%lwt user_tree =
-          Store.Tree.find_tree tree @@ Store.Key.v ["users"; user_id] in
+        let%lwt user_tree = Store.Tree.find_tree tree ["users"; user_id] in
         match user_tree with
         | None ->
           Dream.json ~status:`Not_Found
@@ -945,8 +901,7 @@ struct
             match field with
             | Some "avatar_url" -> Lwt.return (None, None)
             | _ ->
-              let%lwt displayname =
-                Store.Tree.get user_tree @@ Store.Key.v ["username"] in
+              let%lwt displayname = Store.Tree.get user_tree ["username"] in
               Lwt.return (None, Some displayname) in
           let response =
             Response.make ?avatar_url ?displayname ()
@@ -967,8 +922,7 @@ struct
       let open User.Devices in
       let user_id = Dream.param "user_id" request in
       let%lwt tree = Store.tree t.store in
-      let%lwt user_tree =
-        Store.Tree.find_tree tree @@ Store.Key.v ["users"; user_id] in
+      let%lwt user_tree = Store.Tree.find_tree tree ["users"; user_id] in
       match user_tree with
       | None ->
         Dream.json ~status:`Not_Found

--- a/ci-server/helper.ml
+++ b/ci-server/helper.ml
@@ -11,14 +11,12 @@ struct
   let is_room_user (t : Common_routes.t) room_id user_id =
     let%lwt tree = Store.tree t.store in
     let%lwt event_id =
-      Store.Tree.find tree
-        (Store.Key.v ["rooms"; room_id; "state"; "m.room.member"; user_id])
+      Store.Tree.find tree ["rooms"; room_id; "state"; "m.room.member"; user_id]
     in
     match event_id with
     | None -> Lwt.return false
     | Some event_id -> (
-      let%lwt state_event =
-        Store.Tree.get tree (Store.Key.v ["events"; event_id]) in
+      let%lwt state_event = Store.Tree.get tree ["events"; event_id] in
       let state_event =
         Json_encoding.destruct Events.State_event.encoding
           (Ezjsonm.value_from_string state_event) in
@@ -33,9 +31,8 @@ struct
   let time () = Unix.time () |> Float.to_int |> ( * ) 1000
 
   let info (t : Common_routes.t) ?(message = "") () =
-    Irmin.Info.v
-      ~date:(Int64.of_float (Unix.gettimeofday ()))
-      ~author:t.server_name message
+    Store.Info.v ~author:t.server_name ~message
+    @@ Int64.of_float (Unix.gettimeofday ())
 
   let compute_hash_and_sign (t : Common_routes.t) pdu =
     let open Events in
@@ -92,8 +89,7 @@ struct
     sha256
 
   let is_valid_key key_tree =
-    let%lwt valid_until =
-      Store.Tree.get key_tree @@ Store.Key.v ["valid_until"] in
+    let%lwt valid_until = Store.Tree.get key_tree ["valid_until"] in
     let expires_at = Float.of_string valid_until in
     let current_time = Unix.gettimeofday () in
     Lwt.return (expires_at > current_time)
@@ -179,30 +175,24 @@ struct
       let f (key_id, signature) =
         (* check if we have the key, if not, try to fetch it *)
         let%lwt tree = Store.tree t.store in
-        let%lwt key_tree =
-          Store.Tree.find_tree tree @@ Store.Key.v ["keys"; origin; key_id]
-        in
+        let%lwt key_tree = Store.Tree.find_tree tree ["keys"; origin; key_id] in
         let%lwt key_tree =
           if key_tree = None then
             let%lwt key_s = fetching_key t origin key_id in
             match key_s with
             | Some (key_s, valid_until) -> (
               let%lwt tree =
-                Store.Tree.add tree
-                  (Store.Key.v ["keys"; origin; key_id; "key"])
-                  key_s in
+                Store.Tree.add tree ["keys"; origin; key_id; "key"] key_s in
               let%lwt tree =
                 Store.Tree.add tree
-                  (Store.Key.v ["keys"; origin; key_id; "valid_until"])
+                  ["keys"; origin; key_id; "valid_until"]
                   (Int.to_string valid_until) in
               let%lwt return =
                 Store.set_tree
                   ~info:(info t ~message:"add server key")
-                  t.store (Store.Key.v []) tree in
+                  t.store [] tree in
               match return with
-              | Ok () ->
-                Store.Tree.find_tree tree
-                @@ Store.Key.v ["keys"; origin; key_id]
+              | Ok () -> Store.Tree.find_tree tree ["keys"; origin; key_id]
               | Error write_error ->
                 Dream.error (fun m ->
                     m "Write error: %a"
@@ -217,7 +207,7 @@ struct
           let%lwt is_valid = is_valid_key key_tree in
           if not is_valid then Lwt.return_false
           else
-            let%lwt key = Store.Tree.get key_tree (Store.Key.v ["key"]) in
+            let%lwt key = Store.Tree.get key_tree ["key"] in
             is_valid_event_signature signature event key in
       let%lwt checks = Lwt_list.map_p f signatures in
       Lwt.return @@ not @@ List.exists (Bool.equal false) checks
@@ -225,14 +215,13 @@ struct
   (* Use older/replaced events once they are implemented *)
   let get_room_prev_events (t : Common_routes.t) room_id =
     let%lwt tree = Store.tree t.store in
-    let%lwt json =
-      Store.Tree.get tree @@ Store.Key.v ["rooms"; room_id; "head"] in
+    let%lwt json = Store.Tree.get tree ["rooms"; room_id; "head"] in
     let events_id =
       Ezjsonm.from_string json |> Json_encoding.(destruct (list string)) in
     let open Events in
     Lwt_list.fold_left_s
       (fun (d, ids) event_id ->
-        let%lwt json = Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+        let%lwt json = Store.Tree.get tree ["events"; event_id] in
         let event =
           Ezjsonm.from_string json |> Json_encoding.destruct Pdu.encoding in
         Lwt.return (max d (Pdu.get_depth event), ("$" ^ event_id) :: ids))
@@ -241,11 +230,10 @@ struct
   let fetch_joined_servers (t : Common_routes.t) room_id =
     let%lwt tree = Store.tree t.store in
     let%lwt members =
-      Store.Tree.list tree
-      @@ Store.Key.v ["rooms"; room_id; "state"; "m.room.member"] in
+      Store.Tree.list tree ["rooms"; room_id; "state"; "m.room.member"] in
     let f l (_, member_tree) =
-      let%lwt event_id = Store.Tree.get member_tree @@ Store.Key.v [] in
-      let%lwt json = Store.Tree.get tree @@ Store.Key.v ["events"; event_id] in
+      let%lwt event_id = Store.Tree.get member_tree [] in
+      let%lwt json = Store.Tree.get tree ["events"; event_id] in
       let event =
         Json_encoding.destruct Events.State_event.encoding
           (Ezjsonm.value_from_string json) in

--- a/ci-server/matrix_ci_server.ml
+++ b/ci-server/matrix_ci_server.ml
@@ -122,7 +122,7 @@ let main
      let ctx = fill_http ctx federation_port stack in
      let config = Irmin_git.config store_path in
      let%lwt repo = Store.Store.Repo.v config in
-     let%lwt store = Store.Store.master repo in
+     let%lwt store = Store.Store.main repo in
      let info =
        Common_routes.{server_name; key_name; priv_key; pub_key; ctx; store}
      in

--- a/ci-server/matrix_ci_server_setup.ml
+++ b/ci-server/matrix_ci_server_setup.ml
@@ -20,9 +20,9 @@ module User = struct
   let f store user_id password () =
     let config = Irmin_git.config store in
     let%lwt repo = Store.Repo.v config in
-    let%lwt store = Store.master repo in
+    let%lwt store = Store.main repo in
     (* Verify if the user already exists *)
-    let%lwt s_user = Store.find_tree store (Store.Key.v ["users"; user_id]) in
+    let%lwt s_user = Store.find_tree store ["users"; user_id] in
     match s_user with
     | Some _ ->
       Logs.err (fun m -> m "user id %s already exists" user_id);
@@ -34,20 +34,15 @@ module User = struct
       let hashed = Digestif.BLAKE2B.to_hex digest in
       let%lwt tree = Store.tree store in
       let%lwt tree =
-        Store.Tree.add tree (Store.Key.v ["users"; user_id; "username"]) user_id
-      in
-      let%lwt tree =
-        Store.Tree.add tree (Store.Key.v ["users"; user_id; "salt"]) salt in
-      let%lwt tree =
-        Store.Tree.add tree (Store.Key.v ["users"; user_id; "password"]) hashed
-      in
+        Store.Tree.add tree ["users"; user_id; "username"] user_id in
+      let%lwt tree = Store.Tree.add tree ["users"; user_id; "salt"] salt in
+      let%lwt tree = Store.Tree.add tree ["users"; user_id; "password"] hashed in
       let%lwt return =
         Store.set_tree
           ~info:(fun () ->
-            Irmin.Info.v
-              ~date:(Int64.of_float @@ Unix.gettimeofday ())
-              ~author:"matrix-ci-server-setup" "add user")
-          store (Store.Key.v []) tree in
+            Store.Info.v ~author:"matrix-ci-server-setup" ~message:"add user"
+            @@ Int64.of_float (Unix.gettimeofday ()))
+          store [] tree in
       match return with
       | Ok () -> Lwt.return 0
       | Error write_error ->

--- a/ci-server/middleware.ml
+++ b/ci-server/middleware.ml
@@ -41,8 +41,7 @@ struct
       {|{"errcode": "M_UNKNOWN_TOKEN", "error": "No access token matched"}|}
 
   let is_valid_token token_tree =
-    let%lwt expires_at =
-      Store.Tree.get token_tree @@ Store.Key.v ["expires_at"] in
+    let%lwt expires_at = Store.Tree.get token_tree ["expires_at"] in
     let expires_at = Float.of_string expires_at in
     let current_time = Unix.gettimeofday () in
     Lwt.return (expires_at > current_time)
@@ -62,8 +61,7 @@ struct
     | Some token -> (
       let%lwt tree = Store.tree t.store in
       (* fetch the token *)
-      let%lwt token_tree =
-        Store.Tree.find_tree tree @@ Store.Key.v ["tokens"; token] in
+      let%lwt token_tree = Store.Tree.find_tree tree ["tokens"; token] in
       match token_tree with
       | None -> unkown_token
       | Some token_tree -> (
@@ -71,30 +69,25 @@ struct
         if not is_valid then unkown_token
         else
           (* fetch the device *)
-          let%lwt device = Store.Tree.get token_tree @@ Store.Key.v ["device"] in
-          let%lwt device_tree =
-            Store.Tree.find_tree tree (Store.Key.v ["devices"; device]) in
+          let%lwt device = Store.Tree.get token_tree ["device"] in
+          let%lwt device_tree = Store.Tree.find_tree tree ["devices"; device] in
           match device_tree with
           | None -> unkown_token
           | Some device_tree -> (
             (* fetch the user *)
-            let%lwt user_id =
-              Store.Tree.get device_tree @@ Store.Key.v ["user_id"] in
-            let%lwt user_tree =
-              Store.Tree.find_tree tree (Store.Key.v ["users"; user_id]) in
+            let%lwt user_id = Store.Tree.get device_tree ["user_id"] in
+            let%lwt user_tree = Store.Tree.find_tree tree ["users"; user_id] in
             match user_tree with
             | None -> unkown_token
             | Some user_tree -> (
               (* verify the device is still listed in the user's devices *)
               let%lwt user_device =
-                Store.Tree.find_tree user_tree (Store.Key.v ["devices"; device])
-              in
+                Store.Tree.find_tree user_tree ["devices"; device] in
               match user_device with
               | None -> unkown_token
               | Some _ ->
                 (* verify the token is still the actual device token *)
-                let%lwt device_token =
-                  Store.Tree.get device_tree (Store.Key.v ["token"]) in
+                let%lwt device_token = Store.Tree.get device_tree ["token"] in
                 if device_token <> token then unkown_token
                 else
                   handler
@@ -179,28 +172,24 @@ struct
     | Some (origin, key_id, signature) -> (
       let%lwt tree = Store.tree t.store in
       (* fetch the server's key *)
-      let%lwt key_tree =
-        Store.Tree.find_tree tree @@ Store.Key.v ["keys"; origin; key_id] in
+      let%lwt key_tree = Store.Tree.find_tree tree ["keys"; origin; key_id] in
       let%lwt key_tree =
         if key_tree = None then
           let%lwt key_s = Helper.fetching_key t origin key_id in
           match key_s with
           | Some (key_s, valid_until) -> (
             let%lwt tree =
-              Store.Tree.add tree
-                (Store.Key.v ["keys"; origin; key_id; "key"])
-                key_s in
+              Store.Tree.add tree ["keys"; origin; key_id; "key"] key_s in
             let%lwt tree =
               Store.Tree.add tree
-                (Store.Key.v ["keys"; origin; key_id; "valid_until"])
+                ["keys"; origin; key_id; "valid_until"]
                 (Int.to_string valid_until) in
             let%lwt return =
               Store.set_tree
                 ~info:(Helper.info t ~message:"add server key")
-                t.store (Store.Key.v []) tree in
+                t.store [] tree in
             match return with
-            | Ok () ->
-              Store.Tree.find_tree tree @@ Store.Key.v ["keys"; origin; key_id]
+            | Ok () -> Store.Tree.find_tree tree ["keys"; origin; key_id]
             | Error write_error ->
               Dream.error (fun m ->
                   m "Write error: %a"
@@ -215,7 +204,7 @@ struct
         let%lwt is_valid = Helper.is_valid_key key_tree in
         if not is_valid then unkown_key key_id
         else
-          let%lwt key = Store.Tree.get key_tree (Store.Key.v ["key"]) in
+          let%lwt key = Store.Tree.get key_tree ["key"] in
           let%lwt request, is_valid =
             is_valid_signature origin t.server_name signature key request in
           if not is_valid then unkown_key key_id

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -20,8 +20,8 @@ depends: [
   "cmdliner"
   "ezjsonm"
   "fmt"
-  "irmin-fs"
-  "irmin-unix"
+  "irmin-fs" {>= "3.0"}
+  "irmin-unix" {>= "3.0"}
   "logs"
   "tcpip" {>= "7.0.0"}
   "mirage-crypto-ec"


### PR DESCRIPTION
The main goal of this pull request is to move to the recently released irmin 3.0.
We should wait for Irmin.3.0 to be fully released before merging this pull request but at least it is ready.
This PR should also pave the way for the update to [cmdliner.1.1](https://github.com/mirage/ocaml-matrix/pull/18)

The three main changes that impacts the code are the following:
- Renaming of Store.Key to Store.Path
- Moving of Irmin.Info to Store.Info
- Deprecation of master for main

All those changes have been taken into account, however for Store.Key it appeared that using it was not needed at all, so I simply removed it.